### PR TITLE
Initialize credentials as empty dict

### DIFF
--- a/jellyfin_apiclient_python/credentials.py
+++ b/jellyfin_apiclient_python/credentials.py
@@ -20,6 +20,7 @@ class Credentials(object):
 
     def __init__(self):
         LOG.debug("Credentials initializing...")
+        self.credentials = {}
 
     def set_credentials(self, credentials):
         self.credentials = credentials


### PR DESCRIPTION
Hi,

I'd like to merge this tiny change to initialize the credentials upon object creation.
Currently the API prints a warning when you connect to a server before you login.
By initializing the credentials like this, the warning is avoided.

As the _ensure method inside the Credentials class already sets self.credentials to an empty dict when it does not have the proper format, I do not foresee any unwanted side effect.